### PR TITLE
Collapse the proxy into a single in-process asyncio loop

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -69,41 +69,10 @@ EOF
 
 _resolve_default_profile
 
-# ---- Start services ----
-echo "[ENTRYPOINT] Starting WebSocket service on :8000 ..."
-python -m transit_tracker.cli service &
-SERVICE_PID=$!
-
-echo "[ENTRYPOINT] Starting HTTP web server on :8080 ..."
-python -m transit_tracker.cli web &
-WEB_PID=$!
-
-echo "[ENTRYPOINT] Services running (service=$SERVICE_PID, web=$WEB_PID)"
-
-# ---- Wait for either process to exit ----
-# If one dies, kill the other and exit with the failed process's code.
-wait_for_exit() {
-    while true; do
-        # Check if either process has exited
-        if ! kill -0 "$SERVICE_PID" 2>/dev/null; then
-            wait "$SERVICE_PID"
-            EXIT_CODE=$?
-            echo "[ENTRYPOINT] WebSocket service exited ($EXIT_CODE) — shutting down"
-            kill "$WEB_PID" 2>/dev/null || true
-            exit "$EXIT_CODE"
-        fi
-        if ! kill -0 "$WEB_PID" 2>/dev/null; then
-            wait "$WEB_PID"
-            EXIT_CODE=$?
-            echo "[ENTRYPOINT] Web server exited ($EXIT_CODE) — shutting down"
-            kill "$SERVICE_PID" 2>/dev/null || true
-            exit "$EXIT_CODE"
-        fi
-        sleep 1
-    done
-}
-
-# Handle SIGTERM/SIGINT gracefully
-trap 'echo "[ENTRYPOINT] Caught signal — stopping services"; kill "$SERVICE_PID" "$WEB_PID" 2>/dev/null; wait; exit 0' TERM INT
-
-wait_for_exit
+# ---- Start service ----
+# The WebSocket server (:8000), HTTP web server (:8080), and verification
+# monitor now run together in a single asyncio event loop, so one process
+# serves both ports. exec hands the container's main PID to Python so Docker's
+# stop signals reach it directly for a graceful shutdown.
+echo "[ENTRYPOINT] Starting Transit Tracker (WebSocket :8000 + HTTP :8080) ..."
+exec python -m transit_tracker.cli service

--- a/src/transit_tracker/cli.py
+++ b/src/transit_tracker/cli.py
@@ -171,7 +171,19 @@ def _manage_service_launchctl(action: str):
 
 
 async def run_full_service():
-    """Runs both the WebSocket server (for HW) and the notification client."""
+    """Run the proxy, web server, and (in cloud mode) the verification monitor
+    in a single asyncio event loop.
+
+    One ``TransitServer`` instance backs everything. Hardware connects to the
+    ``:8000`` WebSocket server; the ``:8080`` web server shares that same server,
+    so browser ``/ws`` clients and the Home-Assistant tile cache register with
+    it in-process — no loopback TCP hops. In cloud mode the monitor still
+    connects out to the public API to verify it; in local mode the server
+    already holds the data in-process, so no self-connection is made.
+    """
+    from .network.websocket_server import TransitServer
+    from .web import run_web
+
     path = get_last_config_path()
     if path and os.path.exists(path):
         log.info("Loading config from %s", path, extra={"component": "service"})
@@ -179,21 +191,18 @@ async def run_full_service():
     else:
         config = TransitConfig.load()
 
-    tasks = []
+    server = TransitServer(config)
 
-    # Always start the local proxy server (for hardware/monitors)
-    tasks.append(run_server(config=config))
+    tasks = [
+        run_server(config=config, server=server),  # :8000 hardware + background loops
+        run_web(config, server=server),            # :8080 web, in-process /ws + tiles
+    ]
 
-    if config.service.use_local_api:
-        # Force notification client to use the local server we just started
-        config.api_url = "ws://localhost:8000"
-    else:
-        # If using public API, ensure it's not pointing to localhost
+    if not config.service.use_local_api:
+        # Cloud mode: verify the public API with a real (non-loopback) client.
         if "localhost" in config.api_url or "127.0.0.1" in config.api_url:
             config.api_url = "wss://tt.horner.tj/"
-
-    # Notification client connects to configured target (Cloud or Local)
-    tasks.append(run_client(config=config))
+        tasks.append(run_client(config=config))
 
     await asyncio.gather(*tasks)
 

--- a/src/transit_tracker/network/websocket_server.py
+++ b/src/transit_tracker/network/websocket_server.py
@@ -56,6 +56,64 @@ WSF_VESSELS = {
     "69": "Samish", "74": "Chimacum", "75": "Suquamish"
 }
 
+class _InProcessRequest:
+    """Minimal stand-in for the ``request`` attribute of a websockets server
+    connection, so ``TransitServer.register`` can read headers/path uniformly."""
+
+    def __init__(self, path: str = "/", headers: Dict[str, str] = None):
+        self.path = path
+        self.headers = headers or {}
+
+
+class InProcessClient:
+    """Duck-typed websocket that plugs an in-process consumer into
+    ``TransitServer.register`` without a loopback TCP connection.
+
+    The server drives it like any client: it reads our outbound frames via
+    async iteration — we yield a single ``schedule:subscribe`` handshake, then
+    idle until closed — and pushes ``schedule`` updates back through ``send``,
+    which we hand to the ``on_message`` callback. ``remote_address`` defaults
+    to loopback so the server's per-push logging stays quiet, exactly as it did
+    for the old loopback clients.
+    """
+
+    def __init__(
+        self,
+        subscribe_payload: Dict[str, Any],
+        on_message,
+        *,
+        client_name: str = "InProcess",
+        remote_address=("127.0.0.1", 0),
+    ):
+        self._handshake = json.dumps(subscribe_payload)
+        self._sent_handshake = False
+        self._on_message = on_message
+        self._closed = asyncio.Event()
+        self.remote_address = remote_address
+        self.request = _InProcessRequest(
+            path="/", headers={"User-Agent": client_name, "Origin": "in-process"}
+        )
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> str:
+        if not self._sent_handshake:
+            self._sent_handshake = True
+            return self._handshake
+        # Handshake delivered; stay registered until closed/cancelled.
+        await self._closed.wait()
+        raise StopAsyncIteration
+
+    async def send(self, message: str) -> None:
+        result = self._on_message(message)
+        if asyncio.iscoroutine(result):
+            await result
+
+    async def close(self) -> None:
+        self._closed.set()
+
+
 def get_service_state() -> Dict[str, Any]:
     if os.path.exists(SERVICE_STATE_FILE):
         try:
@@ -892,9 +950,22 @@ class TransitServer:
             # Broadcast loop remains consistent to keep hardware alive
             await asyncio.sleep(self.base_interval)
 
-async def run_server(host: str = "0.0.0.0", port: int = 8000, config: TransitConfig = None):
-    if config is None: config = TransitConfig.load()
-    server = TransitServer(config)
+async def run_server(
+    host: str = "0.0.0.0",
+    port: int = 8000,
+    config: TransitConfig = None,
+    server: "TransitServer" = None,
+):
+    """Serve the local proxy on ``:8000`` and run its background loops.
+
+    Pass an existing ``server`` to share one ``TransitServer`` instance with the
+    web server (single-process, in-process clients). Without one, a fresh server
+    is built from ``config`` (standalone use).
+    """
+    if server is None:
+        if config is None:
+            config = TransitConfig.load()
+        server = TransitServer(config)
     log.info("Starting Transit Tracker API on %s:%d", host, port, extra={"component": "server"})
 
     def _process_request(connection, request):

--- a/src/transit_tracker/web/server.py
+++ b/src/transit_tracker/web/server.py
@@ -303,9 +303,18 @@ class TransitWebHandler(BaseHTTPRequestHandler):
 
 
 async def run_web(
-    config: TransitConfig, host: str = "0.0.0.0", port: int = None
+    config: TransitConfig,
+    host: str = "0.0.0.0",
+    port: int = None,
+    server=None,
 ):
-    """Start the Transit Tracker web server with API spec and stop data."""
+    """Start the Transit Tracker web server with API spec and stop data.
+
+    When a shared ``server`` (``TransitServer``) is supplied, browser ``/ws``
+    connections and the Home-Assistant tile cache register with it directly,
+    in-process — no loopback TCP hop to ``:8000``. Without one (standalone
+    ``transit-tracker web``), both fall back to connecting to ``ws://localhost:8000``.
+    """
     if port is None:
         port = int(os.environ.get("PORT", 8080))
 
@@ -330,7 +339,7 @@ async def run_web(
     spec_json = generate_api_spec(config)
     spec_html = generate_spec_html(spec_json)
 
-    tile_cache = TileCache(config)
+    tile_cache = TileCache(config, server=server)
 
     pages = [
         {
@@ -695,9 +704,20 @@ async def run_web(
         headers.append(("Content-Type", "text/html; charset=utf-8"))
         return (404, headers, b"<h1>404 Not Found</h1>")
 
-    # -- WebSocket proxy: relay /ws connections to the internal WS server --
+    # -- WebSocket bridge for /ws connections --
     async def ws_proxy_handler(ws):
-        """Proxy a WebSocket connection to the internal server on :8000."""
+        """Bridge a browser WebSocket to the transit server.
+
+        With a shared in-process ``server`` we register the browser connection
+        directly (no loopback). Standalone, we proxy to the internal server
+        on :8000.
+        """
+        if server is not None:
+            try:
+                await server.register(ws)
+            except websockets.exceptions.ConnectionClosed:
+                pass
+            return
         try:
             async with websockets.connect(
                 "ws://localhost:8000"

--- a/src/transit_tracker/web/tile_cache.py
+++ b/src/transit_tracker/web/tile_cache.py
@@ -33,10 +33,14 @@ class TileCache:
         config: TransitConfig,
         ws_url: str = "ws://localhost:8000",
         tile_limit: int = 5,
+        server=None,
     ):
         self.config = config
         self.ws_url = ws_url
         self.tile_limit = tile_limit
+        # When set, subscribe in-process via TransitServer.register instead of
+        # opening a loopback WebSocket to ``ws_url``.
+        self.server = server
         self.running = True
         # normalised stop_id -> {"trips": [raw_trip, ...], "updated_ms": int}
         self._cache: dict[str, dict] = {}
@@ -143,6 +147,32 @@ class TileCache:
                 "TileCache: no subscriptions configured — skipping",
                 extra={"component": "web"},
             )
+            return
+
+        # Single-process mode: register directly with the shared TransitServer
+        # so the cache is fed in-process, with no loopback TCP connection.
+        if self.server is not None:
+            from ..network.websocket_server import InProcessClient
+
+            def _on_message(raw: str) -> None:
+                try:
+                    msg = json.loads(raw)
+                except (TypeError, json.JSONDecodeError):
+                    return
+                if msg.get("event") == "schedule":
+                    self._ingest_trips(msg.get("data", {}).get("trips", []))
+
+            client = InProcessClient(
+                self.build_subscribe_payload(), _on_message, client_name="TileCache"
+            )
+            log.info(
+                "TileCache attached in-process to TransitServer",
+                extra={"component": "web"},
+            )
+            try:
+                await self.server.register(client)
+            finally:
+                await client.close()
             return
 
         payload_json = json.dumps(self.build_subscribe_payload())


### PR DESCRIPTION
**ARCHITECTURE · PROXY RUNTIME**

# One event loop, one process, zero loopback sockets

> **TL;DR** — The local proxy was already pure asyncio, but it ran as two processes glued together by three loopback WebSocket connections to `ws://localhost:8000`. This collapses the web server, tile cache, and verification monitor onto a single in-process `TransitServer` in one event loop — no TCP self-talk, one container process. No protocol change; 391 tests green.

> [!NOTE]
> **Area** proxy runtime · **Type** refactor / simplification · **Risk** low — single-commit revert; standalone proxy path untouched · **Closes** —

## Why

`entrypoint.sh` launched **two Python processes** (`cli service` + `cli web`), and three consumers reached the transit data by dialing a **loopback WebSocket back to `ws://localhost:8000`**:

1. the verification **monitor** (`websocket_service`) — in local mode the service connected to *itself*;
2. the browser **`/ws` relay** (`web/server` proxy handler);
3. the Home-Assistant **tile cache** (`web/tile_cache`).

Three TCP round-trips, a second process, and a shell `wait_for_exit`/`trap` babysitter — all to move data between objects in the same interpreter.

## What

Everything now hangs off **one `TransitServer` in one event loop**:

- **`InProcessClient`** (new, `websocket_server.py`) — a duck-typed websocket that plugs an in-process consumer straight into `TransitServer.register`: yields one `schedule:subscribe` handshake, idles until closed, forwards pushes to a callback. The server treats it identically to a socket client (register → subscribe → cleanup-on-close).
- **`run_server` / `run_web` / `TileCache`** take an optional shared `server`. When present, browser `/ws` registers **directly** and the tile cache feeds itself **in-process**. When absent, standalone `transit-tracker web` keeps the `:8000` proxy path — backward compatible.
- **`run_full_service`** builds one `TransitServer` and runs the `:8000` server, `:8080` web, background loops, and (cloud mode only) the external monitor under one `asyncio.gather`. Local mode drops the redundant self-monitor.
- **`entrypoint.sh`** `exec`s **one** process; Docker's stop signals reach Python directly.

```mermaid
flowchart TD
  subgraph before["Before — 2 processes, 3 loopback sockets"]
    direction TD
    HW1[ESP32] --> S1[TransitServer 8000]
    M1[monitor] -. loopback .-> S1
    B1[browser] --> W1[web 8080]
    W1 -. loopback .-> S1
    T1[tile cache] -. loopback .-> S1
  end
  subgraph after["After — 1 process, 1 event loop"]
    direction TD
    HW2[ESP32] --> S2[TransitServer 8000]
    B2[browser 8080] --> S2
    T2[tile cache] -->|InProcessClient| S2
    M2[monitor cloud-only] -. real API .-> EXT[wss tt.horner.tj]
  end
```

## Verification

- `uv run pytest -m "not e2e"` → **391 passed, 15 skipped**; `test-and-build` + `build` green on this PR.
- Ruff: 100 pre-existing line-length findings → **98 after** — this change adds none.
- Smoke + integration: `InProcessClient` yields handshake → idles → `StopAsyncIteration` on close; full `TileCache` lifecycle `register → push → ingest → cleanup` against a live `TransitServer`.

## Risk

- **Low / contained.** No protocol or payload change — `InProcessClient` speaks the exact `schedule:subscribe` / `schedule` messages the server already handles.
- **One observable change:** browser `/ws` clients now register with their **real** remote address instead of `127.0.0.1` (the old proxy masked it). Loopback browsers stay quiet in the per-push logs; remote browsers now show in logs and `/api/status` — arguably more correct.
- **Rollback** is a single-commit revert; the standalone proxy path (`server=None`) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uYvR1Xh7g5QNUUMk5YF36