### PR TITLE
chore: rename github URLs tommyroar → robogeosociety

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,6 +1,6 @@
 name: Claude PR Assistant
 
-# Canonical @claude responder — source of truth: tommyroar/.github.
+# Canonical @claude responder — source of truth: robogeosociety/.github.
 # Synced into every owned repo by scripts/sync.sh. Also selectable one-click
 # from the Actions "New workflow" UI. Auth: CLAUDE_CODE_OAUTH_TOKEN (Max sub).
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Canonical pre-commit config — source of truth: tommyroar/.github, synced by scripts/sync.sh.
+# Canonical pre-commit config — source of truth: robogeosociety/.github, synced by scripts/sync.sh.
 # One-time per clone:   uv tool install pre-commit && pre-commit install
 # Ruff version here is kept in lockstep with the ruff run in CI.
 minimum_pre_commit_version: "3.5.0"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,5 +138,5 @@ PR descriptions follow the **newspaper / information-pyramid** format: one self-
 front page (kicker → headline → dek → masthead → why → what → mermaid flow → screens →
 verification → risk) that reads top-to-bottom on an iPad-mini portrait display (1–2 pages;
 up to 4 for very complex *code* changes). Rebuild from the **full** diff, never append.
-Full rules: <https://github.com/tommyroar/.github/blob/main/PR_FRAMEWORK.md>. CI validates
-the body via the `pr-newspaper` workflow (the reusable gate in `tommyroar/pr-newspaper`).
+Full rules: <https://github.com/robogeosociety/.github/blob/main/PR_FRAMEWORK.md>. CI validates
+the body via the `pr-newspaper` workflow (the reusable gate in `robogeosociety/pr-newspaper`).

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -7,7 +7,7 @@ on the dev-wiki changelog page.)
 ## 2026-06-28 — Single-process container (single in-process asyncio loop)
 
 The container now runs one asyncio process instead of two glued by a shell supervisor
-([#69](https://github.com/tommyroar/transit-tracker-tui/pull/69)).
+([#69](https://github.com/robogeosociety/transit-tracker-tui/pull/69)).
 
 - `docker/entrypoint.sh` resolves the active profile, then `exec`s a single process
   (`python -m transit_tracker.cli service`) that serves the WebSocket proxy (`:8000`), the


### PR DESCRIPTION
`fleet` — **ORG RENAME**

Mechanical URL sweep after the tommyroar → robogeosociety org migration — CLAUDE.md PR-framework links, the `.pre-commit-config.yaml` and `claude.yml` source-of-truth comments, and a PR link in `docs/updates.md`. Old github.com URLs redirect, so this is canonical cleanup, not a fix; no Pages project URLs are referenced in this repo.

## Verification
- `grep -rn tommyroar` — remaining hits: 0
- CI checks expected: lint + build (and docker/gemini as configured) on this PR

## Risk & rollout
- Comment/doc/URL-only (no logic change); redirects cover the transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
